### PR TITLE
Hotfix form crud

### DIFF
--- a/client/scripts/controllers/AdminFormsController.js
+++ b/client/scripts/controllers/AdminFormsController.js
@@ -103,7 +103,6 @@ myApp.controller('AdminFormsController', ['$mdDialog', 'AdminService',
      * @param {object} form the form to be deleted
      */
     forms.confirmDelete = function(form) {
-      console.log("this is the data you working with: ", form);
       var confirm = $mdDialog.confirm()
         .title('Are you sure you want to delete this form?')
         .textContent('This will remove the form forever.')

--- a/client/scripts/factories/AdminService.js
+++ b/client/scripts/factories/AdminService.js
@@ -64,7 +64,6 @@ myApp.factory('AdminService', ['$http', '$location',
      * @param {number} id - The form to be removed (specified in AdminFormsController.)
      */
     function deleteForm(id) {
-      console.log('number you got: ', id);
       $http.delete('/forms/delete/' + id).then(function() {
         getAllForms();
       });

--- a/client/scripts/factories/AdminService.js
+++ b/client/scripts/factories/AdminService.js
@@ -42,6 +42,8 @@ myApp.factory('AdminService', ['$http', '$location',
     function addNewForm(formToSend) {
       $http.post('/forms/add', formToSend).then(function(response) {
         getAllForms();
+        formToSend.form_name = '';
+        formToSend.prompts = [];
       });
     }
 
@@ -52,6 +54,8 @@ myApp.factory('AdminService', ['$http', '$location',
     function updateForm(formToSend) {
       $http.put('/forms/update', formToSend).then(function(response) {
         getAllForms();
+        formToSend.form_name = '';
+        formToSend.prompts = [];
       });
     }
 

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -3,11 +3,6 @@ var router = express.Router();
 var pg = require('pg');
 var pool = require('../modules/db');
 
-/**
-* @desc router get request all forms
-* @param
-* @return the results
-*/
 router.get('/', function(req, res) {
   console.log('calling getAllForms on server');
   pool.connect(function(errorConnectingToDb, db, done) {


### PR DESCRIPTION
in the first version of the forms CRUD, question prompts weren't removed from their carrier-array after being sent to the DB on POST/PUT requests. this update fixes that via lines 46 & 58 of AdminService.js