### PR TITLE
Feature session post

### DIFF
--- a/client/scripts/controllers/AdminEventsController.js
+++ b/client/scripts/controllers/AdminEventsController.js
@@ -78,7 +78,7 @@ myApp.controller('AdminEventsController', ['AdminService', '$mdDialog', '$filter
         AdminService.addNewEvent(eventToSend);
       }
       events.clearFields();
-    };
+    };//end sendEvent
 
     events.clearFields = function () {
       events.meeting_count = '';

--- a/client/scripts/controllers/AdminEventsController.js
+++ b/client/scripts/controllers/AdminEventsController.js
@@ -48,7 +48,6 @@ myApp.controller('AdminEventsController', ['AdminService', '$mdDialog', '$filter
     * @param {object} event the event to be edited
     */
     events.editEvent = function(event) {
-      console.log('here the original event', event);
       editingEvent = true;
       events.clearFields();
       events.meeting_count = event.meeting_count;
@@ -72,7 +71,6 @@ myApp.controller('AdminEventsController', ['AdminService', '$mdDialog', '$filter
       eventToSend.close_date = $filter('date')(events.close_date, "yyyy-MM-dd");
       if (editingEvent) {
         editingEvent = false;
-        console.log('here the updated event to send: ', eventToSend);
         AdminService.updateEvent(eventToSend);
       }else {
         AdminService.addNewEvent(eventToSend);
@@ -86,7 +84,6 @@ myApp.controller('AdminEventsController', ['AdminService', '$mdDialog', '$filter
       events.open_date=undefined;
       events.close_date=undefined;
       eventToSend = {};
-      console.log('post clear, eventToSend is: ', eventToSend);
     };
 
   }//end controller function

--- a/client/scripts/controllers/AdminSessionsController.js
+++ b/client/scripts/controllers/AdminSessionsController.js
@@ -5,8 +5,8 @@
  * @return
  */
 
-myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog',
-  function(AdminService, $mdDialog) {
+myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog', '$filter',
+  function(AdminService, $mdDialog, $filter) {
     var sessions = this;
     var chosenYear = '';
     console.log('AdminSessionsController sourced');
@@ -17,6 +17,11 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog',
     sessions.getYearsSessions = AdminService.getYearsSessions;
     sessions.specificYear = AdminService.specificYear;
 
+    sessions.routeToEvents = AdminService.routeToEvents;
+
+    var sessionToSend = {};
+    var editingSession = false;
+
     /**
      * @global object that limits table's display length
      */
@@ -26,7 +31,40 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog',
       page: 1
     };
 
-    sessions.routeToEvents = AdminService.routeToEvents;
+    sessions.days = ("Mondays Tuesdays Wednesdays Thursdays Fridays Saturdays Sundays").split(' ').map(function(day) {
+        return {name: day};
+      });
+
+    sessions.sendSession = function() {
+      sessionToSend.session_count = parseInt(sessions.session_count, 10);
+      if(isNaN(sessionToSend.session_count)){
+        AdminService.sessionConflictPopup();
+        return;
+      }
+      sessionToSend.eventsToAdd = sessions.eventsToAdd;
+      sessionToSend.grade = sessions.grade;
+      sessionToSend.facilitator = sessions.facilitator;
+      sessionToSend.day = sessions.day;
+      sessionToSend.start_time = $filter('date')(sessions.start_time, "hh:mm");
+      sessionToSend.school = sessions.school;
+      sessionToSend.year = sessions.specificYear.sessions[0].year;
+      console.log('here the package: ', sessionToSend);
+      AdminService.addNewSession(sessionToSend);
+      sessions.clearFields();
+    };//end sendSession
+
+    sessions.clearFields = function () {
+      sessions.session_count='';
+      sessions.eventsToAdd='';
+      sessions.grade=undefined;
+      sessions.facilitator='';
+      sessions.day=undefined;
+      sessions.start_time=undefined;
+      sessions.school='';
+      sessionToSend = {};
+      console.log('post clear, sessionToSend is: ', sessionToSend);
+    };
+
 
     sessions.confirmDelete = function(session) {
       var confirm = $mdDialog.confirm()

--- a/client/scripts/controllers/AdminSessionsController.js
+++ b/client/scripts/controllers/AdminSessionsController.js
@@ -20,7 +20,7 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog', '$filt
     sessions.routeToEvents = AdminService.routeToEvents;
 
     var sessionToSend = {};
-    var editingSession = false;
+    sessions.editingSession = false;
 
     /**
      * @global object that limits table's display length
@@ -35,6 +35,23 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog', '$filt
         return {name: day};
       });
 
+      /**
+      * @desc displays a session for editing
+      * @param {object} session the event to be edited
+      */
+      sessions.editSession = function(session) {
+        sessions.editingSession = true;
+        sessions.clearFields();
+        sessions.session_count = session.session_count;
+        sessions.grade = session.grade;
+        sessions.facilitator = session.facilitator;
+        sessions.day = session.day;
+        sessions.start_time = session.start_time;
+        sessions.school = session.school;
+        sessionToSend.id = session.id;
+      };
+
+
     sessions.sendSession = function() {
       sessionToSend.session_count = parseInt(sessions.session_count, 10);
       if(isNaN(sessionToSend.session_count)){
@@ -48,8 +65,13 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog', '$filt
       sessionToSend.start_time = $filter('date')(sessions.start_time, "hh:mm");
       sessionToSend.school = sessions.school;
       sessionToSend.year = sessions.specificYear.sessions[0].year;
-      console.log('here the package: ', sessionToSend);
-      AdminService.addNewSession(sessionToSend);
+      if (sessions.editingSession) {
+        sessions.editingSession = false;
+        AdminService.updateSession(sessionToSend);
+      }else {
+        AdminService.addNewSession(sessionToSend);
+      }
+
       sessions.clearFields();
     };//end sendSession
 
@@ -62,7 +84,6 @@ myApp.controller('AdminSessionsController', ['AdminService', '$mdDialog', '$filt
       sessions.start_time=undefined;
       sessions.school='';
       sessionToSend = {};
-      console.log('post clear, sessionToSend is: ', sessionToSend);
     };
 
 

--- a/client/scripts/factories/AdminService.js
+++ b/client/scripts/factories/AdminService.js
@@ -102,8 +102,32 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
       } else {
         $http.get('/sessions/' + year).then(function(response) {
           specificYear.sessions = response.data;
+          console.log('here are your sessions from db: ', specificYear.sessions);
         });
       }
+    }
+
+    /**
+     * @desc adds new session (and linked events) to db
+     * @param {object} sessionToSend the exit-ticket form to be created
+     */
+    function addNewSession(sessionToSend) {
+      $http.post('/sessions/add', sessionToSend).then(function(response) {
+        getYearsSessions(sessionToSend.year);
+      }, function() {
+        sessionConflictPopup();
+      });
+    }
+
+    function sessionConflictPopup() {
+      $mdDialog.show(
+        $mdDialog.alert()
+        .clickOutsideToClose(true)
+        .title('Cannot Save!')
+        .textContent('Session Count must be a number unique to this Year.')
+        .ariaLabel('Alert Dialog')
+        .ok('OK!')
+      );
     }
 
     /**
@@ -221,7 +245,9 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
       deleteEvent: deleteEvent,
       addNewEvent: addNewEvent,
       meetingConflictPopup: meetingConflictPopup,
-      updateEvent: updateEvent
+      updateEvent: updateEvent,
+      sessionConflictPopup: sessionConflictPopup,
+      addNewSession: addNewSession
     };
 
   }

--- a/client/scripts/factories/AdminService.js
+++ b/client/scripts/factories/AdminService.js
@@ -102,7 +102,6 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
       } else {
         $http.get('/sessions/' + year).then(function(response) {
           specificYear.sessions = response.data;
-          console.log('here are your sessions from db: ', specificYear.sessions);
         });
       }
     }
@@ -131,6 +130,16 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
     }
 
     /**
+     * @desc update session
+     * @param {object} sessionToSend the session to be altered
+     */
+    function updateSession(sessionToSend) {
+      $http.put('/sessions/update', sessionToSend).then(function(response) {
+        getYearsSessions(sessionToSend.year);
+      });
+    }
+
+    /**
      * @desc removes a session, per its ID.
      * @param {object} session - The session to be removed & redisplayed
      */
@@ -154,10 +163,8 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
      * student view landing page, or from an individual entry.
      * @param {number} session_id the session whose events are to be returned
      */
-    function routeToEvents(session_id) {
-      if (session_id) {
-        currentSessionForEvents = session_id;
-      }
+    function routeToEvents(session) {
+        currentSessionForEvents = session.id;
       $location.path("/events");
     }
 
@@ -247,7 +254,8 @@ myApp.factory('AdminService', ['$http', '$location', '$mdDialog',
       meetingConflictPopup: meetingConflictPopup,
       updateEvent: updateEvent,
       sessionConflictPopup: sessionConflictPopup,
-      addNewSession: addNewSession
+      addNewSession: addNewSession,
+      updateSession: updateSession
     };
 
   }

--- a/client/views/templates/adminEvents.html
+++ b/client/views/templates/adminEvents.html
@@ -1,5 +1,3 @@
-<h1>Events for Session number: {{events.specificSession.events[0].session_id }}</h1>
-
 <div layout="row" layout-align="center center" class="admin_table">
   <md-card md-whiteframe="8" flex="90">
     <div layout="row" layout-align="space-around none" class="admin_table">

--- a/client/views/templates/adminSessions.html
+++ b/client/views/templates/adminSessions.html
@@ -23,7 +23,7 @@
         <input ng-model="sessions.session_count">
       </md-input-container>
 
-      <md-input-container>
+      <md-input-container ng-hide="sessions.editingSession">
         <label>Events to Add</label>
         <input ng-model="sessions.eventsToAdd" type="number" min="0" max="20">
       </md-input-container>
@@ -100,7 +100,7 @@
               </md-button>
             </td>
             <td md-cell>
-              <md-button flex="45" aria-label="edit" class="md-raised md-warn admin-button" ng-click="sessions.routeToEvents(session.id)">
+              <md-button flex="45" aria-label="edit" class="md-raised md-warn admin-button" ng-click="sessions.routeToEvents(session)">
                 Events
               </md-button>
             </td>

--- a/client/views/templates/adminSessions.html
+++ b/client/views/templates/adminSessions.html
@@ -13,6 +13,61 @@
   </md-input-container>
 </div>
 
+<!-- Start here -->
+<div layout="row" layout-align="center center">
+  <md-card md-whiteframe="8" flex="90">
+    <div layout="row" layout-align="space-around none">
+
+      <md-input-container>
+        <label>Session Count</label>
+        <input ng-model="sessions.session_count">
+      </md-input-container>
+
+      <md-input-container>
+        <label>Events to Add</label>
+        <input ng-model="sessions.eventsToAdd" type="number" min="0" max="20">
+      </md-input-container>
+
+      <md-input-container>
+        <label>Grade</label>
+        <md-select ng-model="sessions.grade">
+          <md-option ng-value="9"> 9 </md-option>
+          <md-option ng-value="12"> 12 </md-option>
+        </md-select>
+      </md-input-container>
+
+      <md-input-container>
+        <label>Facilitator</label>
+        <input ng-model="sessions.facilitator">
+      </md-input-container>
+
+      <md-input-container>
+        <label>Day</label>
+        <md-select ng-model="sessions.day">
+          <md-option ng-repeat="day in sessions.days" ng-value="day.name">
+            {{day.name}}
+          </md-option>
+        </md-select>
+      </md-input-container>
+
+      <md-input-container>
+        <label>Start Time</label>
+        <input type="time" ng-model="sessions.start_time">
+      </md-input-container>
+
+      <md-input-container>
+        <label>School</label>
+        <input ng-model="sessions.school">
+      </md-input-container>
+
+      <md-input-container>
+        <md-button class="md-primary md-raised" ng-click="sessions.sendSession()">Submit</button>
+      </md-input-container>
+    </div>
+  </md-card>
+</div>
+
+
 
 <div layout="row" layout-align="center center" class="admin_table">
   <md-card md-whiteframe="8" flex="90">

--- a/queries.sql
+++ b/queries.sql
@@ -149,7 +149,7 @@ CREATE TABLE "events" (
   "id" serial primary key,
   "session_id" integer REFERENCES "sessions",
   "meeting_count" integer not null,
-  "form_id" integer REFERENCES "forms",
+  "form_id" integer REFERENCES "forms" DEFAULT 1,
   "date_form_open" date,
   "date_form_close" date,
   UNIQUE ("session_id", "meeting_count")

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -5,6 +5,7 @@ var pool = require('../modules/db');
 
 router.get('/:session', function(req, res) {
   var session = req.params.session;
+  console.log('on server, session is: ', session);
   pool.connect(function(errorConnectingToDb, db, done) {
     if (errorConnectingToDb) {
       res.sendStatus(500);
@@ -15,6 +16,7 @@ router.get('/:session', function(req, res) {
           if (queryError) {
             res.sendStatus(500);
           } else {
+            console.log('the result we returning: ', result.rows);
             res.send(result.rows);
           }
         });
@@ -47,7 +49,6 @@ router.post('/add', function(req, res) {
 }); //end router.post
 
 router.put('/update', function(req, res) {
-  console.log('on server, we got: ', req.body);
   var id = req.body.id;
   var meeting_count = req.body.meeting_count;
   var form_id = req.body.form_id;
@@ -55,7 +56,6 @@ router.put('/update', function(req, res) {
   var close_date = req.body.close_date;
   pool.connect(function(errorConnectingToDb, db, done) {
   if (errorConnectingToDb) {
-    console.log('error connecting: ', errorConnectingToDb);
     res.sendStatus(500);
   } else {
     db.query('UPDATE "events" SET "meeting_count"=$1, "form_id"=$2, "date_form_open"=$3, "date_form_close"=$4 WHERE "id" = $5;',
@@ -63,7 +63,6 @@ router.put('/update', function(req, res) {
       function(queryError, result) {
         done();
         if (queryError) {
-          console.log('error querying: ', queryError);
           res.sendStatus(500);
         } else {
           res.sendStatus(201);

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -43,18 +43,20 @@ router.get('/:year', function(req, res) {
 
 
 router.post('/add', function(req, res) {
-  console.log('on server, we got: ', req.body);
   var year = req.body.year;
+  var eventsToAdd = req.body.eventsToAdd;
   var session_count = req.body.session_count;
   var grade = req.body.grade;
   var facilitator = req.body.facilitator;
   var day = req.body.day;
   var start_time = req.body.start_time;
   var school = req.body.school;
+  var newSessionID;
   pool.connect(function(errorConnectingToDb, db, done) {
     if (errorConnectingToDb) {
       res.sendStatus(500);
     } else {
+      //creates new session
       db.query('INSERT INTO "sessions" ("year", "session_count", "grade", "facilitator", "day", "start_time", "school") VALUES ($1,$2,$3,$4,$5,$6,$7);',
       [year, session_count, grade, facilitator, day, start_time, school],
         function(queryError, result) {
@@ -62,7 +64,30 @@ router.post('/add', function(req, res) {
           if (queryError) {
             res.sendStatus(500);
           } else {
-            res.sendStatus(201);
+            //gets id of new session
+            db.query('SELECT * from "sessions" WHERE "year" = $1 AND "session_count" = $2',
+            [year, session_count],
+            function(queryError, result) {
+              done();
+              if (queryError) {
+                res.sendStatus(500);
+              } else {
+                newSessionID = result.rows[0].id;
+                //creates as many [events to be associated with new session]
+                // as were specified by user
+                for (var i = 0; i < eventsToAdd; i++) {
+                  db.query('INSERT INTO "events" ("session_id", "meeting_count", "form_id") VALUES ($1, $2, $3);',
+                  [newSessionID, i+1, 1],
+                  function(queryError, result) {
+                    done();
+                    if (queryError) {
+                      res.sendStatus(500);
+                    }
+                  });
+                }
+                res.sendStatus(201);
+              }
+            });
           }
         });
     }
@@ -70,6 +95,31 @@ router.post('/add', function(req, res) {
 }); //end router.post
 
 
+router.put('/update', function(req, res) {
+  var id = req.body.id;
+  var session_count = req.body.session_count;
+  var grade = req.body.grade;
+  var facilitator = req.body.facilitator;
+  var day = req.body.day;
+  var start_time = req.body.start_time;
+  var school = req.body.school;
+  pool.connect(function(errorConnectingToDb, db, done) {
+  if (errorConnectingToDb) {
+    res.sendStatus(500);
+  } else {
+    db.query('UPDATE "sessions" SET "session_count"=$1, "grade"=$2, "facilitator"=$3, "day"=$4, "start_time"=$5, "school"=$6 WHERE "id" = $7;',
+    [session_count, grade, facilitator, day, start_time, school, id],
+      function(queryError, result) {
+        done();
+        if (queryError) {
+          res.sendStatus(500);
+        } else {
+          res.sendStatus(201);
+        }
+      });
+    }
+  });
+});//end router.put
 
 router.delete('/delete/:id', function(req, res) {
   var sessionID = req.params.id;

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -42,6 +42,35 @@ router.get('/:year', function(req, res) {
 });//end router.get
 
 
+router.post('/add', function(req, res) {
+  console.log('on server, we got: ', req.body);
+  var year = req.body.year;
+  var session_count = req.body.session_count;
+  var grade = req.body.grade;
+  var facilitator = req.body.facilitator;
+  var day = req.body.day;
+  var start_time = req.body.start_time;
+  var school = req.body.school;
+  pool.connect(function(errorConnectingToDb, db, done) {
+    if (errorConnectingToDb) {
+      res.sendStatus(500);
+    } else {
+      db.query('INSERT INTO "sessions" ("year", "session_count", "grade", "facilitator", "day", "start_time", "school") VALUES ($1,$2,$3,$4,$5,$6,$7);',
+      [year, session_count, grade, facilitator, day, start_time, school],
+        function(queryError, result) {
+          done();
+          if (queryError) {
+            res.sendStatus(500);
+          } else {
+            res.sendStatus(201);
+          }
+        });
+    }
+  });
+}); //end router.post
+
+
+
 router.delete('/delete/:id', function(req, res) {
   var sessionID = req.params.id;
   pool.connect(function(errorConnectingToDb, db, done) {


### PR DESCRIPTION
This branch completes CRUD for sessions and events.

1) **Bug:** when editing sessions, the "start time” input field will not be preloaded as with the other properties. This is because of a discrepancy in the datatypes (`date` object required for `input` tag on DOM, but stored as `time (without time zone)` (?!) in db. I personally don’t rate [the workflow-friction generated by this] worth solving until next week, but can be persuaded if someone else feels strongly.

2) **Incomplete**: there is, as yet, no way to add new years (and linked sessions.) I'll dedicate the first ~hour of tomorrow to writing a POST route similar to the "_add session...but also linked events_" route that's visible in this branch.